### PR TITLE
sepolicy: thermal-engine: allow reading kgsl sysfs

### DIFF
--- a/sepolicy/thermal-engine.te
+++ b/sepolicy/thermal-engine.te
@@ -1,2 +1,3 @@
 set_prop(thermal-engine, diag_prop)
 allow thermal-engine sysfs_batteryinfo:file r_file_perms;
+allow thermal-engine sysfs_kgsl:file r_file_perms;


### PR DESCRIPTION
type=1400 audit(1482423426.553:71): avc: denied { read } for pid=7482 comm="thermal-engine" name="gpu_available_frequencies" dev="sysfs" ino=28723 scontext=u:r:thermal-engine:s0 tcontext=u:object_r:sysfs_kgsl:s0 tclass=file permissive=1
type=1400 audit(1482423426.553:72): avc: denied { open } for pid=7482 comm="thermal-engine" path="/sys/devices/soc/b00000.qcom,kgsl-3d0/kgsl/kgsl-3d0/gpu_available_frequencies" dev="sysfs" ino=28723 scontext=u:r:thermal-engine:s0 tcontext=u:object_r:sysfs_kgsl:s0 tclass=file permissive=1
type=1400 audit(1482423426.553:73): avc: denied { getattr } for pid=7482 comm="thermal-engine" path="/sys/devices/soc/b00000.qcom,kgsl-3d0/kgsl/kgsl-3d0/gpu_available_frequencies" dev="sysfs" ino=28723 scontext=u:r:thermal-engine:s0 tcontext=u:object_r:sysfs_kgsl:s0 tclass=file permissive=1

Change-Id: I665d52c2bc80116454c14abcfccbd8dfacbd00ce
Signed-off-by: Alexander Martinz <eviscerationls@gmail.com>